### PR TITLE
Pertially enable auction history

### DIFF
--- a/packages/nouns-contracts/tasks/deploy-local.ts
+++ b/packages/nouns-contracts/tasks/deploy-local.ts
@@ -23,7 +23,7 @@ task('deploy-local', 'Deploy contracts to hardhat')
     5,
     types.int,
   )
-  .addOptionalParam('auctionDuration', 'The auction duration (seconds)', 60 * 2, types.int) // Default: 2 minutes
+  .addOptionalParam('auctionDuration', 'The auction duration (seconds)', 60 * 3, types.int) // Default: 3 minutes
   .setAction(async (args, { ethers }) => {
     const network = await ethers.provider.getNetwork();
     if (network.chainId !== 31337) {

--- a/packages/nouns-contracts/tasks/run-local.ts
+++ b/packages/nouns-contracts/tasks/run-local.ts
@@ -14,6 +14,7 @@ task(
   await run('populate-descriptor', {
     nftDescriptor: contracts.NFTDescriptor.instance.address,
     nounsDescriptor: contracts.NounsDescriptor.instance.address,
+    autoDeploy: true,
   });
 
   await contracts.NounsAuctionHouse.instance

--- a/packages/nouns-webapp/src/components/Auction/index.tsx
+++ b/packages/nouns-webapp/src/components/Auction/index.tsx
@@ -65,7 +65,7 @@ const Auction: React.FC<AuctionProps> = props => {
       isLastAuction={currentAuction.nounId.eq(lastNounId)}
       onPrevAuctionClick={prevAuctionHandler}
       onNextAuctionClick={nextAuctionHandler}
-      displayGraphDepComps={false}
+      displayGraphDepComps={true}
     />
   );
   const nounderNounContent = currentAuction && lastNounId && (

--- a/packages/nouns-webapp/src/components/AuctionActivity/index.tsx
+++ b/packages/nouns-webapp/src/components/AuctionActivity/index.tsx
@@ -21,6 +21,7 @@ import NounInfoCard from '../NounInfoCard';
 import { useAppSelector } from '../../hooks';
 import BidHistoryModal from '../BidHistoryModal';
 import Holder from '../Holder';
+import { useOpacities } from '../../wrappers/nounToken';
 
 const openEtherscanBidHistory = () => {
   const url = buildEtherscanAddressLink(config.addresses.nounsAuctionHouseProxy);
@@ -50,6 +51,9 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
 
   const [auctionEnded, setAuctionEnded] = useState(false);
   const [auctionTimer, setAuctionTimer] = useState(false);
+
+  const isDummy = auction.opacity == 0;
+  const opacity = useOpacities(auction.nounId)[0]!;
 
   const [showBidHistoryModal, setShowBidHistoryModal] = useState(false);
   const showBidModalHandler = () => {
@@ -105,9 +109,10 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
               <AuctionActivityDateHeadline startTime={auction.startTime} />
             </AuctionTitleAndNavWrapper>
             <Col lg={12}>
-              <AuctionActivityNounTitle isCool={isCool} nounId={auction.nounId} opacity={auction.opacity} />
+              <AuctionActivityNounTitle isCool={isCool} nounId={auction.nounId} opacity={auction.opacity == 0 ? opacity : auction.opacity} />
             </Col>
           </Row>
+          {isDummy ? <></> :
           <Row className={classes.activityRow}>
             <Col lg={4} className={classes.currentBidCol}>
               <CurrentBid
@@ -127,6 +132,7 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
               )}
             </Col>
           </Row>
+          }
         </div>
         {isLastAuction && (
           <>
@@ -137,6 +143,7 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
             </Row>
           </>
         )}
+        {isDummy ? <></> :
         <Row className={classes.activityRow}>
           <Col lg={12}>
             {!isLastAuction ? (
@@ -164,6 +171,7 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
               ))}
           </Col>
         </Row>
+        }
       </AuctionActivityWrapper>
     </>
   );

--- a/packages/nouns-webapp/src/index.tsx
+++ b/packages/nouns-webapp/src/index.tsx
@@ -184,9 +184,43 @@ const ChainSubscriber: React.FC = () => {
   return <></>;
 };
 
+const generateDummyData = (length: number | undefined) => {
+  if (!length) {
+    length = 0;
+  }
+
+  const auctions: any[] = new Array(length);
+  for (let i = 0; i < length; i++) {
+    const auction = {
+      __typename: "Auction",
+      id: i.toString(),
+      amount: "0",
+      settled: true,
+      bidder: {
+        __typename: "",
+        id: "0"
+      },
+      opacity: "0",
+      startTime: "0",
+      endTime: "0",
+      noun: {
+        __typename: "Noun",
+        id: "1",
+        owner: {
+          __typename: "Account",
+          id: "0"
+        }
+      },
+      bids: []
+    };
+    auctions[i] = auction;
+  }
+  return {auctions: auctions}
+}
+
 const PastAuctions: React.FC = () => {
   const latestAuctionId = useAppSelector(state => state.onDisplayAuction.lastAuctionNounId);
-  const { data } = useQuery(latestAuctionsQuery());
+  const data = generateDummyData(latestAuctionId);
   const dispatch = useAppDispatch();
 
   useEffect(() => {

--- a/packages/nouns-webapp/src/wrappers/nounToken.ts
+++ b/packages/nouns-webapp/src/wrappers/nounToken.ts
@@ -168,3 +168,14 @@ export const useTokenOfOwnerNotVoted = (owner: string) => {
     }) || [];
   return ret;
 };
+
+export const useOpacities = (nounId: EthersBN) => {
+  const ret =
+    useContractCall<[number]>({
+      abi,
+      address: config.addresses.nounsToken,
+      method: 'opacities',
+      args: [nounId],
+    }) || [];
+  return ret;
+};


### PR DESCRIPTION
## Summary
Enable history which just shows ID and opacity, related to #1. This is a mid-term solution.


![gn5_fixed](https://user-images.githubusercontent.com/107801646/188063294-d8ffac51-9e85-49b2-8c72-fafdd313c7af.png)

## Detail
It generates dummy history data for all previous IDs. When it's accessed, it retrieves opacity from the contract directly.

## Limitation
If a Ghost Noun is burned (i.e. no one won), loading icon is shown.